### PR TITLE
feat: add configurable sidebar position for floaterm

### DIFF
--- a/lua/floaterm/init.lua
+++ b/lua/floaterm/init.lua
@@ -30,6 +30,10 @@ M.open = function()
 
   local sidebar_w = 20
 
+  if conf.position then 
+     conf.position = type(conf.position) == 'table' and conf.position or conf.position()
+  end
+
   local pos_row = conf.position and conf.position.row or (vim.o.lines / 2 - state.h / 2) - 1
   local pos_col = conf.position and conf.position.col or (vim.o.columns / 2 - state.w / 2)
 

--- a/lua/floaterm/init.lua
+++ b/lua/floaterm/init.lua
@@ -30,9 +30,12 @@ M.open = function()
 
   local sidebar_w = 20
 
+  local pos_row = conf.position and conf.position.row or (vim.o.lines / 2 - state.h / 2) - 1
+  local pos_col = conf.position and conf.position.col or (vim.o.columns / 2 - state.w / 2)
+
   local sidebar_win_opts = {
-    row = (vim.o.lines / 2 - state.h / 2) - 1,
-    col = (vim.o.columns / 2 - state.w / 2),
+    row = pos_row,
+    col = pos_col,
     width = sidebar_w,
     height = state.h,
     relative = "editor",

--- a/lua/floaterm/state.lua
+++ b/lua/floaterm/state.lua
@@ -9,6 +9,7 @@ local M = {
     border = false,
     autoinsert = true,
     size = { h = 60, w = 70 },
+    position = nil,
     -- must be functions
     mappings = { sidebar = nil, term = nil },
     terminals = {

--- a/lua/floaterm/state.lua
+++ b/lua/floaterm/state.lua
@@ -9,7 +9,10 @@ local M = {
     border = false,
     autoinsert = true,
     size = { h = 60, w = 70 },
+
+    -- { row , col } or fn() returning the table
     position = nil,
+
     -- must be functions
     mappings = { sidebar = nil, term = nil },
     terminals = {


### PR DESCRIPTION
Previously, the sidebar window position was always centered based on editor dimensions. This change introduces a new `position` option in the configuration, allowing users to specify custom row and column values for the sidebar. If `position` is not set, the sidebar remains centered by default. This improves flexibility for users who want more control over floaterm window placement.