### PR TITLE
Check if the user is in the side window when deleting/renaming

### DIFF
--- a/lua/floaterm/api.lua
+++ b/lua/floaterm/api.lua
@@ -6,6 +6,10 @@ local M = {}
 M.edit_name = function()
   local row = utils.get_buf_on_cursor()
 
+  if row == nil then
+    row = utils.get_term_by_key(state.buf)[1]
+  end
+
   if row then
     vim.ui.input({ prompt = "   Enter name: " }, function(input)
       state.terminals[row].name = input

--- a/lua/floaterm/api.lua
+++ b/lua/floaterm/api.lua
@@ -4,11 +4,7 @@ local volt_redraw = require("volt").redraw
 local M = {}
 
 M.edit_name = function()
-  local row = utils.get_buf_on_cursor()
-
-  if row == nil then
-    row = utils.get_term_by_key(state.buf)[1]
-  end
+  local row = utils.get_selected_term_index()
 
   if row then
     vim.ui.input({ prompt = "   Enter name: " }, function(input)
@@ -67,7 +63,7 @@ M.delete_term = function(buf)
   local method = buf and "automatic" or "manual"
 
   if not buf then
-    local i = utils.get_buf_on_cursor()
+    local i = utils.get_selected_term_index()
     if i then
       buf = state.terminals[i].buf
     end

--- a/lua/floaterm/utils.lua
+++ b/lua/floaterm/utils.lua
@@ -116,6 +116,10 @@ M.get_term_by_key = function(tocompare, name)
 end
 
 M.get_buf_on_cursor = function()
+  local curwin = vim.api.nvim_get_current_win()
+  if curwin ~= state.sidewin then
+    return nil
+  end
   local row = vim.api.nvim_win_get_cursor(0)[1]
 
   if not state.terminals[row] then

--- a/lua/floaterm/utils.lua
+++ b/lua/floaterm/utils.lua
@@ -130,6 +130,12 @@ M.get_buf_on_cursor = function()
   return row
 end
 
+M.get_selected_term_index = function()
+  local row = M.get_buf_on_cursor()
+  local term = M.get_term_by_key(state.buf)[1]
+  return row or term
+end
+
 M.close_timers = function()
   state.bar_redraw_timer:stop()
   state.bar_redraw_timer:close()


### PR DESCRIPTION
I've noticed, that the way "get_buf_on_cursor" was implemented, it didn't care if the currently active window was the side window. This PR adds a check for this and returns nil otherwise.

Additionally I added in a failsafe to "edit_name" and "delete_term". Previously if these were triggered from the terminal window (and not from the side window), the above bug caused the wrong terminal to be renamed/deleted. I've added a helper function that either returns the selected row if the user is in the side window, or the currently active terminal.

I wanted to control the plugin entirely from the terminal window, never exiting to the sidebar, that's how I ran into this issue.